### PR TITLE
add more cases where the gamemode should be updated

### DIFF
--- a/src/main/java/world/bentobox/parkour/commands/QuitCommand.java
+++ b/src/main/java/world/bentobox/parkour/commands/QuitCommand.java
@@ -3,6 +3,8 @@ package world.bentobox.parkour.commands;
 import java.util.List;
 import java.util.Optional;
 
+import org.bukkit.GameMode;
+
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
@@ -49,6 +51,15 @@ public class QuitCommand extends CompositeCommand {
     @Override
     public boolean execute(User user, String label, List<String> args) {
         ((Parkour)getAddon()).getParkourRunManager().clear(user.getUniqueId());
+        Optional<Island> islandOptional = getAddon().getIslands().getIslandAt(user.getLocation());
+        islandOptional.ifPresent(island -> {
+            if (island.getFlag(((Parkour) getAddon()).CREATIVE_FLAG) <= island.getRank(user)) {
+            user.setGameMode(GameMode.CREATIVE);
+        } else {
+            user.setGameMode(GameMode.SURVIVAL);
+        }
+        });
+
         user.sendMessage("parkour.quit.success");
         return true;
     }

--- a/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
+++ b/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
@@ -56,7 +56,7 @@ public class CourseRunnerListener extends AbstractListener {
     public void onVisitorArrive(IslandEnterEvent e) {
         // Check if visitor
         User user = User.getInstance(e.getPlayerUUID());
-        if (user == null || !user.isOnline() || !addon.inWorld(e.getLocation())) {
+        if (user == null || !user.isOnline()) {
             return;
         }
         Island island = e.getIsland();

--- a/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
+++ b/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
@@ -119,7 +119,7 @@ public class CourseRunnerListener extends AbstractListener {
             case ENDER_PEARL, CHORUS_FRUIT, DISMOUNT, EXIT_BED -> false;
             case COMMAND, PLUGIN, NETHER_PORTAL, END_PORTAL, SPECTATE, END_GATEWAY, UNKNOWN -> true;
         };
-        if (shouldStopRun) {
+        if (shouldStopRun && parkourRunManager.getTimers().containsKey(e.getPlayer().getUniqueId())) {
             User user = User.getInstance(e.getPlayer().getUniqueId());
             if (parkourRunManager.getCheckpoints().containsKey(e.getPlayer().getUniqueId()) && user.isOnline()) {
                 user.notify("parkour.session-ended");
@@ -127,7 +127,7 @@ public class CourseRunnerListener extends AbstractListener {
             parkourRunManager.clear(e.getPlayer().getUniqueId());
         }
 
-        if (e.getTo() != null) {
+        if (e.getTo() != null && !parkourRunManager.getTimers().containsKey(e.getPlayer().getUniqueId())) {
             Optional<Island> fromIsland = addon.getIslands().getIslandAt(e.getFrom());
             Optional<Island> toIsland = addon.getIslands().getIslandAt(e.getTo());
 

--- a/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
+++ b/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
@@ -68,11 +68,11 @@ public class CourseRunnerListener extends AbstractListener {
             user.notify("parkour.no-end-yet");
         } else if (!parkourRunManager.getTimers().containsKey(e.getPlayerUUID())) {
             user.notify("parkour.to-start");
-            if (island.getFlag(addon.CREATIVE_FLAG) <= island.getRank(user)) {
-                user.setGameMode(GameMode.CREATIVE);
-            } else {
-                user.setGameMode(GameMode.SURVIVAL);
-            }
+        }
+        if (island.getFlag(addon.CREATIVE_FLAG) <= island.getRank(user)) {
+            user.setGameMode(GameMode.CREATIVE);
+        } else {
+            user.setGameMode(GameMode.SURVIVAL);
         }
     }
 

--- a/src/test/java/world/bentobox/parkour/commands/QuitCommandTest.java
+++ b/src/test/java/world/bentobox/parkour/commands/QuitCommandTest.java
@@ -110,6 +110,7 @@ public class QuitCommandTest {
         when(prm.getTimers()).thenReturn(Map.of(uuid, 20L));
 
         // Islands
+        when(addon.getIslands()).thenReturn(im);
         when(plugin.getIslands()).thenReturn(im);
         when(im.getIsland(world, user)).thenReturn(island);
         when(im.getIslandAt(location)).thenReturn(Optional.of(island));
@@ -205,6 +206,7 @@ public class QuitCommandTest {
     public void testExecuteUserStringListOfString() {
         assertTrue(cmd.execute(user, "", List.of()));
         verify(user).sendMessage("parkour.quit.success");
+
         verify(prm).clear(uuid);
     }
 


### PR DESCRIPTION
also cancels run on certain types of teleport 
COMMAND, PLUGIN, NETHER_PORTAL, END_PORTAL, SPECTATE, END_GATEWAY, UNKNOWN

allowed types are
ENDER_PEARL, CHORUS_FRUIT, DISMOUNT, EXIT_BED
iirc fully preventable using per-island / global flags anyway, and some parkour may want to use these in the course