### PR TITLE
fix repeated checkpoint setting + bypass teleport check for back-to-checkpoint teleports + fix replacing checkpoints with the pressure plate

### DIFF
--- a/src/main/java/world/bentobox/parkour/Parkour.java
+++ b/src/main/java/world/bentobox/parkour/Parkour.java
@@ -1,5 +1,6 @@
 package world.bentobox.parkour;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 
 import org.bukkit.Material;
@@ -91,7 +92,7 @@ public class Parkour extends GameModeAddon implements Listener {
         adminCommand = new DefaultAdminCommand(this) {
         };
 
-        parkourRunRecord = new ParkourRunRecord(new HashMap<>(), new HashMap<>());
+        parkourRunRecord = new ParkourRunRecord(new HashMap<>(), new HashMap<>(), new ArrayList<>());
 
         registerFlag(PARKOUR_CREATIVE);
 

--- a/src/main/java/world/bentobox/parkour/ParkourRunRecord.java
+++ b/src/main/java/world/bentobox/parkour/ParkourRunRecord.java
@@ -1,11 +1,12 @@
 package world.bentobox.parkour;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import org.bukkit.Location;
 
-public record ParkourRunRecord(Map<UUID, Location> checkpoints, Map<UUID, Long> timers) {
+public record ParkourRunRecord(Map<UUID, Location> checkpoints, Map<UUID, Long> timers, List<UUID> currentlyTeleporting) {
     /**
      * Clears any current times or checkpoints
      * @param uuid UUID of runner
@@ -13,6 +14,7 @@ public record ParkourRunRecord(Map<UUID, Location> checkpoints, Map<UUID, Long> 
     public void clear(UUID uuid) {
         checkpoints.remove(uuid);
         timers.remove(uuid);
+        currentlyTeleporting.remove(uuid);
     }
 
 }

--- a/src/main/java/world/bentobox/parkour/commands/WarpCommand.java
+++ b/src/main/java/world/bentobox/parkour/commands/WarpCommand.java
@@ -19,8 +19,8 @@ import world.bentobox.parkour.ParkourManager;
 
 /**
  * Warps to a
- * @author tastybento
  *
+ * @author tastybento
  */
 public class WarpCommand extends CompositeCommand {
 
@@ -48,7 +48,7 @@ public class WarpCommand extends CompositeCommand {
         }
         if (args.isEmpty()) {
             Optional<Island> island = getIslands().getIslandAt(user.getLocation());
-            if (island.isEmpty() || !((Parkour)getAddon()).inWorld(user.getWorld())) {
+            if (island.isEmpty() || !((Parkour) getAddon()).inWorld(user.getWorld())) {
                 user.sendMessage("parkour.errors.not-on-island");
                 this.showHelp(this, user);
                 return false;
@@ -81,18 +81,18 @@ public class WarpCommand extends CompositeCommand {
         // Teleport user
         user.getPlayer().playSound(user.getLocation(), Sound.ENTITY_BAT_TAKEOFF, 1F, 1F);
         user.getPlayer().playSound(warpSpot, Sound.ENTITY_BAT_TAKEOFF, 1F, 1F);
-        Util.teleportAsync(user.getPlayer(), warpSpot.clone().add(new Vector(0.5, 0.5, 0.5)), TeleportCause.COMMAND);
+        Util.teleportAsync(user.getPlayer(), warpSpot, TeleportCause.COMMAND);
         return true;
     }
 
     @Override
     public Optional<List<String>> tabComplete(User user, String alias, List<String> args) {
-        ArrayList<String> options = new ArrayList<>(((Parkour)getAddon()).getParkourManager().getWarps().keySet());
+        ArrayList<String> options = new ArrayList<>(((Parkour) getAddon()).getParkourManager().getWarps().keySet());
         if (options.size() < 10) {
             return Optional.of(options);
         }
         // List is too long; require at least the first letter
-        String lastArg = !args.isEmpty() ? args.get(args.size()-1) : "";
+        String lastArg = !args.isEmpty() ? args.get(args.size() - 1) : "";
         if (args.isEmpty()) {
             return Optional.empty();
         }

--- a/src/main/java/world/bentobox/parkour/gui/CoursesTab.java
+++ b/src/main/java/world/bentobox/parkour/gui/CoursesTab.java
@@ -10,7 +10,6 @@ import java.util.UUID;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
-import org.bukkit.util.Vector;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -25,9 +24,9 @@ import world.bentobox.parkour.objects.ParkourData;
 
 /**
  * Implements a {@link Tab} that shows course rankings
+ *
  * @author tastybento
  * @since 1.0.0
- *
  */
 public class CoursesTab implements Tab {
 
@@ -36,8 +35,9 @@ public class CoursesTab implements Tab {
 
     /**
      * Show a tab of settings
+     *
      * @param addon - addon
-     * @param user - user who is viewing the tab
+     * @param user  - user who is viewing the tab
      */
     public CoursesTab(Parkour addon, User user) {
         super();
@@ -47,6 +47,7 @@ public class CoursesTab implements Tab {
 
     /**
      * Get the icon for this tab
+     *
      * @return panel item
      */
     @Override
@@ -69,6 +70,7 @@ public class CoursesTab implements Tab {
 
     /**
      * Get all the flags as panel items
+     *
      * @return list of all the panel items for this flag type
      */
     @Override
@@ -78,20 +80,21 @@ public class CoursesTab implements Tab {
         List<PanelItem> heads = new ArrayList<>();
         // Sort the courses by runs
         addon.getParkourManager().getParkourData().stream()
-        .sorted()
-        .filter(hs -> Objects.nonNull(hs.getWarpSpot()))
-        .forEach(hs -> {
-            UUID owner = addon.getIslands().getIslandById(hs.getUniqueId()).map(Island::getOwner).orElse(null);
-            if (owner != null) {
-                heads.add(getHead(hs, owner));
-            }
-        });
+                .sorted()
+                .filter(hs -> Objects.nonNull(hs.getWarpSpot()))
+                .forEach(hs -> {
+                    UUID owner = addon.getIslands().getIslandById(hs.getUniqueId()).map(Island::getOwner).orElse(null);
+                    if (owner != null) {
+                        heads.add(getHead(hs, owner));
+                    }
+                });
         return heads;
     }
 
     /**
      * Get the head panel item
-     * @param pd - parkour data
+     *
+     * @param pd         - parkour data
      * @param playerUUID - the UUID of the owner
      * @return PanelItem
      */
@@ -115,7 +118,7 @@ public class CoursesTab implements Tab {
                 .clickHandler((panel, user, clickType, slot) -> {
                     user.sendMessage("parkour.warp.warping");
                     // Teleport user
-                    Util.teleportAsync(user.getPlayer(), pd.getWarpSpot().clone().add(new Vector(0.5, 1, 0.5)), TeleportCause.COMMAND);
+                    Util.teleportAsync(user.getPlayer(), pd.getWarpSpot(), TeleportCause.COMMAND);
                     return true;
                 })
                 .description(description);

--- a/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
+++ b/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
@@ -3,6 +3,7 @@ package world.bentobox.parkour.listeners;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.bukkit.EntityEffect;
 import org.bukkit.GameMode;
@@ -113,27 +114,32 @@ public class CourseRunnerListener extends AbstractListener {
         player.playEffect(EntityEffect.ENTITY_POOF);
         player.setVelocity(new Vector(0, 0, 0));
         player.setFallDistance(0);
-        player.teleport(parkourRunManager.checkpoints().get(player.getUniqueId()));
+        Location checkpointLocation = parkourRunManager.checkpoints().get(player.getUniqueId());
+        checkpointLocation = checkpointLocation.clone().add(0.5, 0, 0.5);
+        parkourRunManager.currentlyTeleporting().add(player.getUniqueId());
+        player.teleport(checkpointLocation);
+        parkourRunManager.currentlyTeleporting().remove(player.getUniqueId());
 
     }
 
     @EventHandler
     public void onTeleport(PlayerTeleportEvent e) {
         boolean shouldStopRun = switch (e.getCause()) {
-        case ENDER_PEARL, CHORUS_FRUIT, DISMOUNT, EXIT_BED -> false;
-        case COMMAND, PLUGIN, NETHER_PORTAL, END_PORTAL, SPECTATE, END_GATEWAY, UNKNOWN -> true;
+            case ENDER_PEARL, CHORUS_FRUIT, DISMOUNT, EXIT_BED -> false;
+            case COMMAND, PLUGIN, NETHER_PORTAL, END_PORTAL, SPECTATE, END_GATEWAY, UNKNOWN -> true;
         };
-        if (shouldStopRun && parkourRunManager.timers().containsKey(e.getPlayer().getUniqueId())) {
-            User user = User.getInstance(e.getPlayer().getUniqueId());
-            if (parkourRunManager.checkpoints().containsKey(e.getPlayer().getUniqueId()) && user.isOnline()) {
+        UUID playerUUID = e.getPlayer().getUniqueId();
+        if (!parkourRunManager.currentlyTeleporting().contains(playerUUID) && shouldStopRun && parkourRunManager.timers().containsKey(playerUUID)) {
+            User user = User.getInstance(playerUUID);
+            if (parkourRunManager.checkpoints().containsKey(playerUUID) && user.isOnline()) {
                 user.notify("parkour.session-ended");
             }
-            parkourRunManager.clear(e.getPlayer().getUniqueId());
+            parkourRunManager.clear(playerUUID);
         }
         // Check world - only apply flag actions to Parkour world and only if player is not actively running the course
         if (e.getTo() == null // To can sometimes be null...
                 || !addon.inWorld(e.getTo())
-                || parkourRunManager.timers().containsKey(e.getPlayer().getUniqueId())) {
+                || parkourRunManager.timers().containsKey(playerUUID)) {
             return;
         }
         // Handle flag action for players who are not running
@@ -205,14 +211,14 @@ public class CourseRunnerListener extends AbstractListener {
             return;
         }
 
-        Location l = e.getClickedBlock().getLocation();
+        Location blockLocation = e.getClickedBlock().getLocation();
         User user = User.getInstance(e.getPlayer());
-        addon.getIslands().getProtectedIslandAt(l).ifPresent(island -> {
+        addon.getIslands().getProtectedIslandAt(blockLocation).ifPresent(island -> {
             Optional<Location> start = addon.getParkourManager().getStart(island);
             Optional<Location> end = addon.getParkourManager().getEnd(island);
 
             // Check if start and end is set
-            if (start.filter(startLoc -> isLocEquals(l, startLoc)).isPresent()) {
+            if (start.filter(startLoc -> isLocEquals(blockLocation, startLoc)).isPresent()) {
                 // End is not set
                 if (end.isEmpty()) {
                     user.sendMessage("parkour.set-the-end");
@@ -220,29 +226,29 @@ public class CourseRunnerListener extends AbstractListener {
                 }
                 // Start the race!
                 if (!parkourRunManager.timers().containsKey(e.getPlayer().getUniqueId())) {
-                    parkourStart(user, l);
+                    parkourStart(user, blockLocation);
                 }
-            } else if (end.filter(endLoc -> isLocEquals(l, endLoc)).isPresent()
+            } else if (end.filter(endLoc -> isLocEquals(blockLocation, endLoc)).isPresent()
                     && parkourRunManager.timers().containsKey(e.getPlayer().getUniqueId())) {
                 // End the race!
-                parkourEnd(user, island, l);
+                parkourEnd(user, island, blockLocation);
             }
         });
     }
 
-    void parkourStart(User user, Location l) {
+    void parkourStart(User user, Location blockLocation) {
         user.sendMessage("parkour.start");
-        user.getPlayer().playSound(l, Sound.ENTITY_FIREWORK_ROCKET_LAUNCH, 1F, 1F);
+        user.getPlayer().playSound(blockLocation, Sound.ENTITY_FIREWORK_ROCKET_LAUNCH, 1F, 1F);
         parkourRunManager.timers().put(user.getUniqueId(), System.currentTimeMillis());
-        parkourRunManager.checkpoints().put(user.getUniqueId(), user.getLocation());
+        parkourRunManager.checkpoints().put(user.getUniqueId(), blockLocation);
         user.setGameMode(GameMode.SURVIVAL);
 
     }
 
-    void parkourEnd(User user, Island island, Location l) {
+    void parkourEnd(User user, Island island, Location blockLocation) {
         long duration = (System.currentTimeMillis() - Objects.requireNonNull(parkourRunManager.timers().get(user.getUniqueId())));
         user.notify("parkour.end");
-        user.getPlayer().playSound(l, Sound.ENTITY_FIREWORK_ROCKET_LAUNCH, 1F, 1F);
+        user.getPlayer().playSound(blockLocation, Sound.ENTITY_FIREWORK_ROCKET_LAUNCH, 1F, 1F);
         user.notify("parkour.you-took", TextVariables.NUMBER, getDuration(user, duration));
         parkourRunManager.clear(user.getUniqueId());
 
@@ -279,14 +285,18 @@ public class CourseRunnerListener extends AbstractListener {
                 || !parkourRunManager.timers().containsKey(e.getPlayer().getUniqueId())) {
             return;
         }
-        Location l = e.getClickedBlock().getLocation();
-        User user = User.getInstance(e.getPlayer());
-        Vector checkPoint = parkourRunManager.checkpoints().get(e.getPlayer().getUniqueId()).toVector();
-
-        if (addon.getIslands().getProtectedIslandAt(l).isPresent() && !l.toVector().equals(checkPoint)) {
-            user.notify("parkour.checkpoint");
-            e.getPlayer().playSound(l, Sound.BLOCK_BELL_USE, 1F, 1F);
-            parkourRunManager.checkpoints().put(user.getUniqueId(), e.getPlayer().getLocation());
+        Location newCheckpointBlockLocation = e.getClickedBlock().getLocation();
+        if (addon.getIslands().getProtectedIslandAt(newCheckpointBlockLocation).isPresent()) {
+            // pressure plate should be a checkpoint
+            Location currentCheckpointBlockLocation = parkourRunManager.checkpoints().get(e.getPlayer().getUniqueId());
+            if (!isLocEquals(newCheckpointBlockLocation, currentCheckpointBlockLocation)) {
+                // new location is different
+                User user = User.getInstance(e.getPlayer());
+                user.sendMessage("parkour.checkpoint");
+                e.getPlayer().playSound(newCheckpointBlockLocation, Sound.BLOCK_BELL_USE, 1F, 1F);
+                parkourRunManager.checkpoints().put(user.getUniqueId(), newCheckpointBlockLocation);
+            }
         }
     }
+
 }

--- a/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
+++ b/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
@@ -29,6 +29,7 @@ import world.bentobox.bentobox.api.events.island.IslandExitEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.util.Util;
 import world.bentobox.parkour.Parkour;
 import world.bentobox.parkour.ParkourRunRecord;
 
@@ -117,9 +118,8 @@ public class CourseRunnerListener extends AbstractListener {
         Location checkpointLocation = parkourRunManager.checkpoints().get(player.getUniqueId());
         checkpointLocation = checkpointLocation.clone().add(0.5, 0, 0.5);
         parkourRunManager.currentlyTeleporting().add(player.getUniqueId());
-        player.teleport(checkpointLocation);
-        parkourRunManager.currentlyTeleporting().remove(player.getUniqueId());
-
+        Util.teleportAsync(player, checkpointLocation, PlayerTeleportEvent.TeleportCause.PLUGIN)
+                .thenAccept(b -> parkourRunManager.currentlyTeleporting().remove(player.getUniqueId()));
     }
 
     @EventHandler

--- a/src/main/java/world/bentobox/parkour/listeners/MakeCourseListener.java
+++ b/src/main/java/world/bentobox/parkour/listeners/MakeCourseListener.java
@@ -50,10 +50,11 @@ public class MakeCourseListener extends AbstractListener {
             Optional<Location> warpSpot = addon.getParkourManager().getWarpSpot(island);
             if (warpSpot.isEmpty()) {
                 user.notify("parkour.warp.set");
-                addon.getParkourManager().setWarpSpot(island, l);
             } else {
                 user.notify("parkour.warp.replaced");
             }
+            // shift from block to player location
+            addon.getParkourManager().setWarpSpot(island, l.add(0.5,0,0.5));
         }
     }
 

--- a/src/test/java/world/bentobox/parkour/commands/QuitCommandTest.java
+++ b/src/test/java/world/bentobox/parkour/commands/QuitCommandTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -109,7 +110,7 @@ public class QuitCommandTest {
         when(ac.getWorld()).thenReturn(world);
         when(ac.getAddon()).thenReturn(addon);
 
-        prm = new ParkourRunRecord(new HashMap<>(), new HashMap<>());
+        prm = new ParkourRunRecord(new HashMap<>(), new HashMap<>(), new ArrayList<>());
         prm.timers().put(uuid, 20L);
         when(addon.getParkourRunRecord()).thenReturn(prm);
 

--- a/src/test/java/world/bentobox/parkour/commands/WarpCommandTest.java
+++ b/src/test/java/world/bentobox/parkour/commands/WarpCommandTest.java
@@ -142,7 +142,6 @@ public class WarpCommandTest {
 
         // Location
         when(location.clone()).thenReturn(location);
-        when(location.add(any(Vector.class))).thenReturn(location);
 
         // Settings
         Settings settings = new Settings();
@@ -267,7 +266,6 @@ public class WarpCommandTest {
         verify(user).sendMessage("parkour.warp.warping");
         // Teleport user
         verify(p, times(2)).playSound(location, Sound.ENTITY_BAT_TAKEOFF, 1F, 1F);
-        verify(location).add(any(Vector.class));
         PowerMockito.verifyStatic(Util.class);
         Util.teleportAsync(p, location, TeleportCause.COMMAND);
 

--- a/src/test/java/world/bentobox/parkour/listeners/CourseRunnerListenerTest.java
+++ b/src/test/java/world/bentobox/parkour/listeners/CourseRunnerListenerTest.java
@@ -1,19 +1,5 @@
 package world.bentobox.parkour.listeners;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -72,12 +58,15 @@ import world.bentobox.parkour.ParkourManager;
 import world.bentobox.parkour.ParkourRunRecord;
 import world.bentobox.parkour.Settings;
 
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
 /**
  * @author tastybento
- *
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Bukkit.class, BentoBox.class, User.class })
+@PrepareForTest({Bukkit.class, BentoBox.class, User.class})
 public class CourseRunnerListenerTest {
 
     @Mock
@@ -190,7 +179,9 @@ public class CourseRunnerListenerTest {
 
         // Location
         when(location.getWorld()).thenReturn(world);
-        when(location.toVector()).thenReturn(new Vector(0,0,0));
+        when(location.toVector()).thenReturn(new Vector(0, 0, 0));
+        when(location.clone()).thenReturn(location);
+        when(location.add(0.5, 0, 0.5)).thenReturn(location);
 
         // Run Manager and ParkourManager
         prm = new ParkourRunRecord(new HashMap<>(), new HashMap<>(), new ArrayList<>());
@@ -523,7 +514,7 @@ public class CourseRunnerListenerTest {
     @Test
     public void testOnCheckpointInitialChecks() {
         Location l = mock(Location.class);
-        when(l.toVector()).thenReturn(new Vector(100,0,20)); // Different to location
+        when(l.toVector()).thenReturn(new Vector(100, 0, 20)); // Different to location
         prm.checkpoints().put(uuid, l);
 
         when(block.getType()).thenReturn(Material.STONE);

--- a/src/test/java/world/bentobox/parkour/listeners/CourseRunnerListenerTest.java
+++ b/src/test/java/world/bentobox/parkour/listeners/CourseRunnerListenerTest.java
@@ -193,7 +193,7 @@ public class CourseRunnerListenerTest {
         when(location.toVector()).thenReturn(new Vector(0,0,0));
 
         // Run Manager and ParkourManager
-        prm = new ParkourRunRecord(new HashMap<>(), new HashMap<>());
+        prm = new ParkourRunRecord(new HashMap<>(), new HashMap<>(), new ArrayList<>());
         when(addon.getParkourRunRecord()).thenReturn(prm);
         when(addon.inWorld(location)).thenReturn(true);
         when(addon.inWorld(world)).thenReturn(true);


### PR DESCRIPTION
various fixes

add list of players that are currently teleporting, and should be ignored from canceling their run parkourRunRecord
change the checkpoint manager to store block locations, teleporting players to the middle of the block on recall.
(better comparison to avoid re-setting the location on the same block)