### PR TITLE
add permission check for changing gamemode

### DIFF
--- a/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
+++ b/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
@@ -217,6 +217,10 @@ public class CourseRunnerListener extends AbstractListener {
     }
 
     private void updateGamemode(Island island, User user) {
+        if (user.hasPermission("parkour.mod.bypassgamemodechange")) {
+            return;
+        }
+
         if (island.getFlag(addon.PARKOUR_CREATIVE) <= island.getRank(user)) {
             user.setGameMode(GameMode.CREATIVE);
         } else {

--- a/src/main/resources/addon.yml
+++ b/src/main/resources/addon.yml
@@ -40,6 +40,9 @@ permissions:
   parkour.mod.bypasslock:
     description: Bypasses an course lock
     default: op
+  parkour.mod.bypassgamemodechange:
+    description: Bypasses the changing of your gamemode when entering your island.
+    default: false
   parkour.mod.bypassban:
     description: Bypasses course ban
     default: op
@@ -88,18 +91,6 @@ permissions:
     default: op
   parkour.mod.team.setowner:
     description: Allow use of '/pkadmin team setowner' command - transfers course ownership to the player
-    default: op
-  parkour.mod.team.add:
-    description: Allow use of '/pkadmin add' command - add player to owner's team
-    default: op
-  parkour.mod.team.kick:
-    description: Allow use of '/pkadmin kick' command - kick a player from a team
-    default: op
-  parkour.mod.team.disband:
-    description: Allow use of '/pkadmin disband' command - disband owner's team
-    default: op
-  parkour.mod.team.setowner:
-    description: Allow use of '/pkadmin setowner' command - transfers course ownership to the player
     default: op
   parkour.admin.blueprint:
     description: Allow use of '/pkadmin blueprint' command - manipulate blueprints
@@ -169,9 +160,6 @@ permissions:
     default: op
   parkour.admin.resets.add:
     description: Allow use of '/pkadmin resets add' command - adds this player's course reset count
-    default: op
-  parkour.admin.resets.remove:
-    description: Allow use of '/pkadmin resets remove' command - reduces the player's course reset count
     default: op
   parkour.admin.delete:
     description: Allow use of '/pkadmin delete' command - deletes a player and regenerates their course
@@ -295,9 +283,6 @@ permissions:
     default: true
   parkour.island.team.coop:
     description: Allow use of '/parkour team coop' command - make a player coop rank on your course
-    default: true
-  parkour.island.team.coop:
-    description: Allow use of '/parkour team uncoop' command - remove a coop rank from player
     default: true
   parkour.island.team.trust:
     description: Allow use of '/parkour team trust', '/parkour team untrust' command - remove trusted player rank from player


### PR DESCRIPTION
still excludes actually playing the course
not given by default to avoid op perms including it
`parkour.mod.bypassgamemodechange`