### PR TITLE
Fix void-fall crash on Paper 1.21.11 (issue #23 follow-up)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.5.0</build.version>
+        <build.version>1.5.1</build.version>
         <sonar.organization>bentobox-world</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>

--- a/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
+++ b/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
@@ -6,10 +6,10 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
-import org.bukkit.EntityEffect;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -176,7 +176,8 @@ public class CourseRunnerListener extends AbstractListener {
         }
         // Put player back to last checkpoint (or the course start if no checkpoint reached yet).
         // If the event is not cancelled the player still takes some damage.
-        player.playEffect(EntityEffect.ENTITY_POOF);
+        // ENTITY_POOF is not applicable to players (Paper rejects it), so spawn the particles directly.
+        player.getWorld().spawnParticle(Particle.POOF, player.getLocation(), 20, 0.5, 0.5, 0.5, 0.1);
         player.setVelocity(new Vector(0, 0, 0));
         player.setFallDistance(0);
         Location checkpointLocation = parkourRunManager.checkpoints().get(player.getUniqueId());

--- a/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
+++ b/src/main/java/world/bentobox/parkour/listeners/CourseRunnerListener.java
@@ -177,7 +177,10 @@ public class CourseRunnerListener extends AbstractListener {
         // Put player back to last checkpoint (or the course start if no checkpoint reached yet).
         // If the event is not cancelled the player still takes some damage.
         // ENTITY_POOF is not applicable to players (Paper rejects it), so spawn the particles directly.
-        player.getWorld().spawnParticle(Particle.POOF, player.getLocation(), 20, 0.5, 0.5, 0.5, 0.1);
+        Location playerLoc = player.getLocation();
+        if (playerLoc != null) {
+            player.getWorld().spawnParticle(Particle.POOF, playerLoc, 20, 0.5, 0.5, 0.5, 0.1);
+        }
         player.setVelocity(new Vector(0, 0, 0));
         player.setFallDistance(0);
         Location checkpointLocation = parkourRunManager.checkpoints().get(player.getUniqueId());

--- a/src/test/java/world/bentobox/parkour/listeners/CourseRunnerListenerTest.java
+++ b/src/test/java/world/bentobox/parkour/listeners/CourseRunnerListenerTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
@@ -22,10 +24,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.bukkit.EntityEffect;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -286,7 +288,7 @@ class CourseRunnerListenerTest extends CommonTestSetup {
         crl.onVisitorFall(e);
         // prevent-void-death defaults to true, so the player is saved from dying
         assertTrue(e.isCancelled());
-        verify(mockPlayer).playEffect(EntityEffect.ENTITY_POOF);
+        verify(world).spawnParticle(eq(Particle.POOF), eq(location), anyInt(), anyDouble(), anyDouble(), anyDouble(), anyDouble());
         verify(mockPlayer).setVelocity(new Vector(0, 0, 0));
         verify(mockPlayer).setFallDistance(0);
         // Verify static call
@@ -309,7 +311,7 @@ class CourseRunnerListenerTest extends CommonTestSetup {
         crl.onVisitorFall(e);
         // prevent-void-death is off, so the player still takes damage (event not cancelled)
         assertFalse(e.isCancelled());
-        verify(mockPlayer).playEffect(EntityEffect.ENTITY_POOF);
+        verify(world).spawnParticle(eq(Particle.POOF), eq(location), anyInt(), anyDouble(), anyDouble(), anyDouble(), anyDouble());
         verify(mockPlayer).setVelocity(new Vector(0, 0, 0));
         verify(mockPlayer).setFallDistance(0);
         // Verify static call
@@ -326,7 +328,7 @@ class CourseRunnerListenerTest extends CommonTestSetup {
         prm.checkpoints().put(uuid, location);
         EntityDamageEvent e = new EntityDamageEvent(mockPlayer, DamageCause.BLOCK_EXPLOSION, null, 0);
         crl.onVisitorFall(e);
-        verify(mockPlayer, never()).playEffect(EntityEffect.ENTITY_POOF);
+        verify(world, never()).spawnParticle(eq(Particle.POOF), any(Location.class), anyInt(), anyDouble(), anyDouble(), anyDouble(), anyDouble());
         verify(mockPlayer, never()).setVelocity(new Vector(0, 0, 0));
         verify(mockPlayer, never()).setFallDistance(0);
         verify(mockPlayer, never()).teleport(location);
@@ -340,7 +342,7 @@ class CourseRunnerListenerTest extends CommonTestSetup {
     void testOnVisitorFallNotRunning() {
         EntityDamageEvent e = new EntityDamageEvent(mockPlayer, DamageCause.VOID, null, 1D);
         crl.onVisitorFall(e);
-        verify(mockPlayer, never()).playEffect(EntityEffect.ENTITY_POOF);
+        verify(world, never()).spawnParticle(eq(Particle.POOF), any(Location.class), anyInt(), anyDouble(), anyDouble(), anyDouble(), anyDouble());
         verify(mockPlayer, never()).setVelocity(new Vector(0, 0, 0));
         verify(mockPlayer, never()).setFallDistance(0);
         verify(mockPlayer, never()).teleport(location);
@@ -355,7 +357,7 @@ class CourseRunnerListenerTest extends CommonTestSetup {
         Creeper creeper = mock(Creeper.class);
         EntityDamageEvent e = new EntityDamageEvent(creeper, DamageCause.VOID, null, 1D);
         crl.onVisitorFall(e);
-        verify(creeper, never()).playEffect(EntityEffect.ENTITY_POOF);
+        verify(world, never()).spawnParticle(eq(Particle.POOF), any(Location.class), anyInt(), anyDouble(), anyDouble(), anyDouble(), anyDouble());
     }
 
     /**


### PR DESCRIPTION
## Summary

Follow-up to #23: falling into the void during a run threw
`IllegalArgumentException: Entity effect cannot apply to this entity` from
`CourseRunnerListener.onVisitorFall` (reported in
https://github.com/BentoBoxWorld/Parkour/issues/23#issuecomment-5008704033).

Paper 1.21.11 validates that an `EntityEffect` is applicable to the entity type, and
`EntityEffect.ENTITY_POOF` is not valid for players. The listener now spawns the poof
particles directly via `World#spawnParticle(Particle.POOF, ...)` at the player's
location, which gives the same visual without the entity-effect API.

Also bumps `<build.version>` to **1.5.1**.

## Changes
- `CourseRunnerListener#onVisitorFall`: `player.playEffect(EntityEffect.ENTITY_POOF)` → `world.spawnParticle(Particle.POOF, ...)`
- `CourseRunnerListenerTest`: verifications updated to match
- `pom.xml`: version 1.5.0 → 1.5.1

## Testing
- `mvn test`: 307 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127BygdZbwCH2VxfjgyETvb